### PR TITLE
Add bug and feature request issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,52 @@
+name: Bug report
+description: Report a bug in evergit
+title: '[BUG] '
+labels: ['bug']
+
+body:
+    - type: markdown
+      attributes:
+          value: |
+              Thanks for taking the time to fill out this bug report!
+
+    - type: input
+      id: evergit_version
+      attributes:
+          label: evergit version
+          description: Please provide the version of evergit you are using.
+          placeholder: 'e.g. 1.0.0'
+
+    - type: input
+      id: node_version
+      attributes:
+          label: Node version
+          description: Please provide the version of Node.js you are using.
+          placeholder: 'e.g. 14.17.0'
+
+    - type: textarea
+      id: description
+      attributes:
+          label: Bug description
+          description: Please provide a clear and concise description of the bug.
+          placeholder: 'Describe the bug'
+
+    - type: textarea
+      id: steps_to_reproduce
+      attributes:
+          label: Steps to reproduce
+          description: Please provide the steps to reproduce the bug.
+          placeholder: 'Steps to reproduce'
+
+    - type: textarea
+      id: expected_behavior
+      attributes:
+          label: Expected behavior
+          description: Please describe what you expected to happen.
+          placeholder: 'Describe the expected behavior'
+
+    - type: textarea
+      id: additional_context
+      attributes:
+          label: Additional context
+          description: Add any other context about the problem here. For example, screenshots, logs, etc.
+          placeholder: 'Add any other context about the problem here'

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,42 @@
+name: Feature request
+description: Suggest an idea for this project
+title: '[FEATURE] '
+labels: ['enhancement']
+
+body:
+    - type: markdown
+      attributes:
+          value: |
+              Thanks for taking the time to open a feature request! Please provide us with as much detail as possible to help us understand your idea.
+
+    - type: input
+      id: feature
+      attributes:
+          label: Feature description
+          description: Please describe the feature you would like to see
+          placeholder: Describe the feature here
+      validations:
+          required: true
+
+    - type: textarea
+      id: motivation
+      attributes:
+          label: Motivation
+          description: Why do you want this feature? What problem does it solve?
+          placeholder: Explain why this feature should be implemented
+      validations:
+          required: true
+
+    - type: input
+      id: alternatives
+      attributes:
+          label: Alternatives
+          description: Are there any alternative solutions or features you've considered?
+          placeholder: Describe any alternative solutions here
+
+    - type: textarea
+      id: additional-context
+      attributes:
+          label: Additional context
+          description: Add any other context or screenshots about the feature request here
+          placeholder: Add any other context or screenshots here

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -22,5 +22,5 @@ jobs:
             - name: Prettify code
               uses: creyD/prettier_action@v4.3
               with:
-                  prettier_options: --write "**/*.{js,ts,md,json}" --config .prettierrc
+                  prettier_options: --write "**/*.{js,ts,json}" --config .prettierrc
                   only_changed: False

--- a/.github/workflows/pre-publish.yml
+++ b/.github/workflows/pre-publish.yml
@@ -4,6 +4,8 @@ on:
     pull_request:
         branches:
             - main
+        paths:
+            - 'src/**'
 
 jobs:
     prettier-check:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,8 @@ on:
     push:
         branches:
             - main
+        paths:
+            - 'src/**'
 
 jobs:
     publish:

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "scripts": {
         "start": "node dist/main.js",
         "build": "tsc",
-        "format": "prettier --write .",
-        "format-check": "prettier --check .",
+        "format": "prettier --write . --config .prettierrc",
+        "format-check": "prettier --check . --config .prettierrc",
         "check-unused": "ts-prune -p tsconfig.json",
         "prepare": "npm run build",
         "test": "jest",


### PR DESCRIPTION
- Implement new GitHub issue template for bug reports, guiding users to provide essential details such as evergit and Node.js versions, steps for reproduction, and additional context.
- Add feature request template to standardize feature suggestion submissions with required fields for description and motivation.
- Update publish workflow to trigger on changes in 'src/' directory and amended indentation for clarity.

Release-Note: Add GitHub issue templates for bug reports and feature requests